### PR TITLE
config: Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jidicula

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,22 @@
 version: 2
 updates:
-# Maintain dependencies for GitHub Actions
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-    day: "saturday"
-    time: "06:00"
-    timezone: "America/Toronto"
-  reviewers:
-    - "jidicula"
-  open-pull-requests-limit: 99
-  commit-message:
-    prefix: "build: "
-- package-ecosystem: "gomod"
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: "saturday"
-    time: "06:00"
-    timezone: "America/Toronto"
-  reviewers:
-    - "jidicula"
-  commit-message:
-    prefix: "build: "
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "06:00"
+      timezone: "America/Toronto"
+    open-pull-requests-limit: 99
+    commit-message:
+      prefix: "build: "
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "saturday"
+      time: "06:00"
+      timezone: "America/Toronto"
+    commit-message:
+      prefix: "build: "


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners